### PR TITLE
docs: fixed Twitter link inconsistency in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A curated list of resources for learning and programming in Noir.
 
 [![Awesome](https://awesome.re/badge-flat.svg)](https://awesome.re)
-[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/Aztec.svg?style=social&label=Follow%20%40Aztec)](https://twitter.com/aztecnetwork)
+[![Twitter](https://img.shields.io/twitter/url/https/twitter.com/aztecnetwork.svg?style=social&label=Follow%20%40aztecnetwork)](https://twitter.com/aztecnetwork)
 
 ## Official Resources
 


### PR DESCRIPTION
 I noticed that the Twitter link in the text points to `https://twitter.com/aztecnetwork`, but the mention in the text is `@Aztec`, this inconsistency could confuse readers.

I've updated the link to match the mention, ensuring clarity and accuracy.