### PR TITLE
Add Aztec Packages and Docs tutorial link

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ A curated list of resources for learning and programming in Noir.
 - [Writing a Token Bridge](https://docs.aztec.network/developers/tutorials/codealong/contract_tutorials/token_bridge)
 - [Aztec Contracts 0–100](https://medium.com/@niallinio/aztec-contracts-0-100-905fe41bf998)
 - [Learn Aztec](https://github.com/taurushq-io/private-CMTAT-aztec/blob/master/LEARN-AZTEC.md) by Taurus
+- [How to use Aztec Packages and Aztec Docs](https://gist.github.com/rajeshb62/60a7018d97124b5644d84c4f3ea5cc18)
 
 ## Coding
 


### PR DESCRIPTION
Added a new tutorial link to the Tutorials section that helps developers understand how to effectively use Aztec documentation and packages- aztec-nr, aztec.js and aztec-cli.

Changes made:
- Added link to "How to use Aztec Packages and Aztec Docs" tutorial in the Tutorials section