### PR TITLE
ShieldSwap -> Nemi

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ A curated list of resources for learning and programming in Noir.
 
 ### Projects
 
-- [Shieldswap](https://app.shieldswap.org/) - swap tokens with privacy
+- [Nemi](https://nemi.fi) - swap tokens with privacy
 - [Interface to the example token contract](https://github.com/defi-wonderland/aztec-token)
 - [(Experimental) NFT Standards](https://github.com/resurgencelabs/nft_standards)
 - [Private subscription service](https://github.com/resurgencelabs/ikigai_backend)


### PR DESCRIPTION
We are getting rid of the shieldswap.org domain next year, so makes sense to remove all mentions of it