### PR TITLE
docs: add hyperlinks to libraries 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,9 @@ A curated list of resources for learning and programming in Noir.
 
 - [Aztec.nr docs](https://docs.aztec.network/guides/smart_contracts/writing_contracts/initializers) and [source code](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/aztec-nr)
   - Includes:
-    - `aztec` (core) - the core of the framework
-    - `easy-private-state` - for easily creating private state
-    - `safe-math` - for safe arithmetic
-    - `value-note` - for storing arbitrary values
+    - [`aztec`](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/aztec-nr/aztec) (core) - the core of the framework
+    - [`easy-private-state`](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/aztec-nr/easy-private-state) - for easily creating private state
+    - [`value-note`](https://github.com/AztecProtocol/aztec-packages/tree/master/noir-projects/aztec-nr/value-note) - for storing arbitrary values
 - [Noir libraries](https://github.com/noir-lang/awesome-noir/blob/main/README.md#libraries) - can be used in Aztec contracts
 - [Aztec Storage proofs](https://github.com/nemi-fi/aztec_storage_proofs) - Prove Aztec note inclusion in plain Noir. Generate verifiable proofs for verification in JS or Solidity.
 


### PR DESCRIPTION
added links to libraries and deleted `safe-math` because it seems that we dont have this library in https://github.com/AztecProtocol/aztec-packages . if i am wrong let me know i will fix.