### PR TITLE
Freshness review: fix renamed link, remove stale/unmaintained entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [Learn Aztec](https://github.com/taurushq-io/private-CMTAT-aztec/blob/master/LEARN-AZTEC.md) by Taurus
 - [How to use Aztec Packages and Aztec Docs](https://gist.github.com/rajeshb62/60a7018d97124b5644d84c4f3ea5cc18)
 - [Play the Glass Bridge Game (ZK Tutorial)](https://zkdev.net/docs/tutorial/glass-bridge)
-- [Aztec Personal AI Tutor](https://github.com/0xdfinity/Aztec-AI)
 
 ## Coding
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,6 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [Azguard](https://azguardwallet.io/) - Browser wallet
 - [Nemi](https://nemi.fi) - AMM: swap tokens with privacy
 - [RavenHouse](https://www.ravenhouse.xyz/) - NFT Marketplace and NFt private ownership verification.
-- [(Experimental) NFT Standards](https://github.com/resurgencelabs/nft_standards)
-- [Private subscription service](https://github.com/resurgencelabs/ikigai_backend)
 - [Dark Forest (Aztec port)](https://github.com/dfarchon/dark-forest-aztec) - Aztec port of the Dark Forest game
 - [Galactica zkKYC](https://github.com/Galactica-corp/aztec-zkkyc) - zkKYC implementation on Aztec
 - [Play](https://play.aztec-labs.com/) - Aztec Labs playground

--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [Noir VS Code extension](https://marketplace.visualstudio.com/items?itemName=noir-lang.vscode-noir) - Syntax highlighting, snippets and more for Noir.
 - [aztec.tools](https://aztec.tools) - collection of handy tools for Aztec development in the browser.
 - [Aztec Test Runner](https://github.com/marketplace/actions/aztec-test-runner) - a Github Action for running TXE tests in your CI
-- [Remix IDE Plugin for Aztec](https://github.com/hsy822/aztec-remix-plugin) - a plugin for Remix IDE to compile, deploy, and interact with Aztec smart contracts.
 - [Demo wallet](https://github.com/AztecProtocol/demo-wallet) -  An Aztec wallet application (designed for devs) that allows dApps to interact with user accounts through a secure interface
 - [Aztec MCP Server](https://github.com/AztecProtocol/mcp-server) - An MCP (Model Context Protocol) server that provides local access to Aztec documentation, examples, and source code through cloned repositories.
 - [Aztec Claude Code Plugin](https://github.com/critesjosh/aztec-claude-plugin) - A Claude Code plugin for Aztec smart contract and application development. 
@@ -87,7 +86,6 @@ A curated list of resources for learning and programming the Aztec blockchain.
 
 - [Aztec Starter](https://github.com/AztecProtocol/aztec-starter) - A starting point for writing Aztec contracts and tests (and learning!)
 - [Aztec web starter](https://github.com/AztecProtocol/aztec-web-starter) - an example web app that demonstrates how to interact with an Aztec contract using the Aztec JS SDK
-- [Next.js Starter](https://github.com/raven-house/aztec-nextjs-starter) - Next.js starter template with Aztec Network integration
 - [Defi Wonderland's Aztec Boilerplate](https://github.com/defi-wonderland/aztec-boilerplate) - similar to Aztec starter, but includes benchmarking on PRs
 - [Aztec Boxes](https://github.com/AztecProtocol/aztec-packages/tree/master/boxes) - A collection of boilerplates for building with Aztec
   - [Install local network](https://docs.aztec.network/developers/getting_started_on_local_network)

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [RavenHouse](https://www.ravenhouse.xyz/) - NFT Marketplace and NFt private ownership verification.
 - [(Experimental) NFT Standards](https://github.com/resurgencelabs/nft_standards)
 - [Private subscription service](https://github.com/resurgencelabs/ikigai_backend)
-- [Aztec NFT Playground](https://github.com/0xandee/aztec-nft-playground) - Privacy-preserving NFT trading protocol on Aztec with encrypted ownership (formerly Tezac)
 - [Dark Forest (Aztec port)](https://github.com/dfarchon/dark-forest-aztec) - Aztec port of the Dark Forest game
 - [Galactica zkKYC](https://github.com/Galactica-corp/aztec-zkkyc) - zkKYC implementation on Aztec
 - [Play](https://play.aztec-labs.com/) - Aztec Labs playground

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [Aztec Test Runner](https://github.com/marketplace/actions/aztec-test-runner) - a Github Action for running TXE tests in your CI
 - [Remix IDE Plugin for Aztec](https://github.com/hsy822/aztec-remix-plugin) - a plugin for Remix IDE to compile, deploy, and interact with Aztec smart contracts.
 - [Demo wallet](https://github.com/AztecProtocol/demo-wallet) -  An Aztec wallet application (designed for devs) that allows dApps to interact with user accounts through a secure interface
-- [Aztec MCP Server](https://github.com/critesjosh/aztec-mcp-server) - An MCP (Model Context Protocol) server that provides local access to Aztec documentation, examples, and source code through cloned repositories.
+- [Aztec MCP Server](https://github.com/AztecProtocol/mcp-server) - An MCP (Model Context Protocol) server that provides local access to Aztec documentation, examples, and source code through cloned repositories.
 - [Aztec Claude Code Plugin](https://github.com/critesjosh/aztec-claude-plugin) - A Claude Code plugin for Aztec smart contract and application development. 
 - [Aztec Lint](https://github.com/NethermindEth/aztec-lint/blob/main/docs/lints-reference.md) - Nethermind's linter for Aztec contracts
 - [Lampe](https://github.com/reilabs/lampe/tree/main) - Lean-based formal verification framework for Noir programs

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [Learn Aztec](https://github.com/taurushq-io/private-CMTAT-aztec/blob/master/LEARN-AZTEC.md) by Taurus
 - [How to use Aztec Packages and Aztec Docs](https://gist.github.com/rajeshb62/60a7018d97124b5644d84c4f3ea5cc18)
 - [Play the Glass Bridge Game (ZK Tutorial)](https://zkdev.net/docs/tutorial/glass-bridge)
-- [Aztec Personal AI Tutor](https://github.com/Atunde-SS/Aztec-AI.git)
+- [Aztec Personal AI Tutor](https://github.com/0xdfinity/Aztec-AI)
 
 ## Coding
 
@@ -128,10 +128,9 @@ A curated list of resources for learning and programming the Aztec blockchain.
 - [RavenHouse](https://www.ravenhouse.xyz/) - NFT Marketplace and NFt private ownership verification.
 - [(Experimental) NFT Standards](https://github.com/resurgencelabs/nft_standards)
 - [Private subscription service](https://github.com/resurgencelabs/ikigai_backend)
-- [Tezac](https://github.com/0xandee/tezac/) - Privacy-preserving NFT marketplace
-- [Dark Forest (Aztec port)](https://github.com/dfarchon/dfpunk-aztec/tree/cherry/temp) - Aztec port of the Dark Forest game
+- [Aztec NFT Playground](https://github.com/0xandee/aztec-nft-playground) - Privacy-preserving NFT trading protocol on Aztec with encrypted ownership (formerly Tezac)
+- [Dark Forest (Aztec port)](https://github.com/dfarchon/dark-forest-aztec) - Aztec port of the Dark Forest game
 - [Galactica zkKYC](https://github.com/Galactica-corp/aztec-zkkyc) - zkKYC implementation on Aztec
-- [Galactica threshold decryption](https://github.com/Galactica-corp/aztec-v4-issue-sample) - Threshold decryption sample in Noir and TypeScript ([demo recording](https://drive.google.com/file/d/1NxH8hjfRrqeUsI-o7mUti-HidyF_kGSV/view))
 - [Play](https://play.aztec-labs.com/) - Aztec Labs playground
 - [Aztec Swap](https://swap.aztec-kit.anothercoffeefor.me/) - Swap UI
 - [Aztec Bridge](https://bridge.aztec-kit.anothercoffeefor.me/) [[source](https://github.com/aztec-labs-eng/aztec-kit)]- Bridge UI


### PR DESCRIPTION
Acting on a repo-staleness freshness review ([pass 1](https://gist.github.com/AztecBot/48fca9b21333a25d4798f6384a0eb184), [pass 1 complete](https://gist.github.com/AztecBot/985ef2c07b37dade8382850bf4f5bd83)). **Every flagged repo was independently re-verified against the GitHub API** before any edit; the original diff was cross-reviewed by a second tool (OpenAI Codex). Only confirmed findings are included.

## Changes

| Entry | Change | Why |
|---|---|---|
| Aztec MCP Server | Link `critesjosh/aztec-mcp-server` → `AztecProtocol/mcp-server` | Moved into the official org; active (pushed 2026-06-23) |
| Dark Forest (Aztec port) | Link `dfarchon/dfpunk-aztec/tree/cherry/temp` → `dfarchon/dark-forest-aztec` | Repo renamed, active on `main`; dropped stale temp-branch suffix |
| ~~Tezac / Aztec NFT Playground~~ (`0xandee/aztec-nft-playground`) | **Removed** | Stale — last commit 2025-07-26 (~11 months) |
| ~~Remix IDE Plugin for Aztec~~ (`hsy822/aztec-remix-plugin`) | **Removed** | Stale — last commit 2025-04-15 (~14.5 months) |
| ~~Next.js Starter~~ (`raven-house/aztec-nextjs-starter`) | **Removed** | Stale — last commit 2025-08-26 (~10 months) |
| ~~Private subscription service~~ (`resurgencelabs/ikigai_backend`) | **Removed** | Abandoned — last commit 2023-11-07 (~2.6 years) |
| ~~(Experimental) NFT Standards~~ (`resurgencelabs/nft_standards`) | **Removed** | Abandoned — last commit 2023-11-07 (~2.6 years) |
| ~~Galactica threshold decryption~~ (`aztec-v4-issue-sample`) | **Removed** | 2 KB, 0★, v4-era throwaway bug-repro — a support artifact, not a durable project |
| ~~Aztec Personal AI Tutor~~ (`0xdfinity/Aztec-AI`) | **Removed** | Content cannot stay current by design — see below |

### Why remove Aztec Personal AI Tutor

It's a Google AI Studio export ("Copy of Aztec AI Tutor"). Its entire knowledge is a **hardcoded string** baked into `services/geminiService.ts`, and the system prompt forces Gemini to treat it as the *"ONLY source of information"* — **no web grounding, no retrieval, no fetch of docs/llms.txt**. There is no update mechanism (no CI, no scheduled job). All 4 commits landed in a single 14-minute window on **2025-09-29** and it has been untouched for ~9 months (0★, no license). The frozen text already drifts from the live stack (pins `gemini-2.5-flash`, points `aztec-starter` at `main` while the list uses `next`, bakes in churny install/CLI flows). It can't stay up to date, so it's being removed.

## Flagged by the review but intentionally left unchanged (verified live)

- **`AztecProtocol/demo-wallet`** — flagged "not public / broken" by **both** review passes, but re-checked live on 2026-06-30: it is **public and active** (pushed 2026-06-19, 4★). This is a repeated false-negative in the reviewer's public-repo probe. **No change.**
- **`taurushq-io/private-CMTAT-aztec`** and **`nemi-fi/aztec_storage_proofs`** — "recheck" items; both confirmed alive (Dec 2025). **No change.**
- **Azguard** add-candidate — already listed under Projects. **No change.**

## Out of scope (noted, not fixed)

- The Bridge UI line has a pre-existing formatting nit (`)]- Bridge UI`, missing a space) unrelated to this review.

Opening as **draft** for maintainer review.